### PR TITLE
Bugfix : problem with upglifyjs parameters parsing

### DIFF
--- a/src/Assetic/Filter/UglifyJs2Filter.php
+++ b/src/Assetic/Filter/UglifyJs2Filter.php
@@ -61,7 +61,7 @@ class UglifyJs2Filter extends BaseNodeFilter
     {
         $this->comments = $comments;
     }
-    
+
     public function setWrap($wrap)
     {
         $this->wrap = $wrap;
@@ -77,12 +77,16 @@ class UglifyJs2Filter extends BaseNodeFilter
             ? array($this->nodeBin, $this->uglifyjsBin)
             : array($this->uglifyjsBin));
 
+        // @note about ARGS.alias and uglify
+        // "--compress hoist_vars=false" is badly parsed as ARGS['compress hoist_vars'] = false in bin/uglify ...
+        // "-c hoist_vars=false" is successfully parsed as ARGS['compress'] = { hoist_vars:false } in bin/uglify
         if ($this->compress) {
-            $pb->add(true === $this->compress ? '--compress' : '--compress '.$this->compress);
+            $pb->add(true === $this->compress ? '--compress' : '-c '.$this->compress);
         }
 
+        // https://github.com/mishoo/UglifyJS2 : 'beautify' can equal "false/true" or list of options
         if ($this->beautify) {
-            $pb->add('--beautify');
+            $pb->add(true === $this->beautify ? '--beautify' : '-b '.$this->beautify);
         }
 
         if ($this->mangle) {
@@ -96,7 +100,7 @@ class UglifyJs2Filter extends BaseNodeFilter
         if ($this->comments) {
             $pb->add('--comments')->add(true === $this->comments ? 'all' : $this->comments);
         }
-        
+
         if ($this->wrap) {
             $pb->add('--wrap')->add($this->wrap);
         }


### PR DESCRIPTION
Résolution d'un problème de passage de paramètre à uglifyjs
Les alias sont actuellement mal gérés sous uglifyjs.

Voici comment les paramètres "compress" et "beautify" sont actuellement parsés :
- commande : "uglifyjs --compress hoist_vars=false --beautify ascii_only=true,quote_keys=true"
- ARGS sous uglify : ARGS = { 'compress hoist_vars': false, 'beautify ascii_only': 'true,quote_keys=true' }
- du fait de ce mauvais parsing, les paramètres fournis ne sont pas interprétés

Après ce commit, on obtient à la place : 
- ARGS = { 'compress': { 'hoist_vars': false}, 'beautify' : { 'ascii_only': true, 'quote_keys': true } }
